### PR TITLE
Fixes formatting on repr(Rust) page.

### DIFF
--- a/src/repr-rust.md
+++ b/src/repr-rust.md
@@ -4,8 +4,8 @@ First and foremost, all types have an alignment specified in bytes. The
 alignment of a type specifies what addresses are valid to store the value at. A
 value of alignment `n` must only be stored at an address that is a multiple of
 `n`. So alignment 2 means you must be stored at an even address, and 1 means
-that you can be stored anywhere. Alignment is at least 1, and always a power of
-2. Most primitives are generally aligned to their size, although this is
+that you can be stored anywhere. Alignment is at least 1, and always a power
+of 2. Most primitives are generally aligned to their size, although this is
 platform-specific behavior. In particular, on x86 `u64` and `f64` may be only
 aligned to 32 bits.
 


### PR DESCRIPTION
A line starting with `2.` unfortunately emits `<ol start="2">`, causing the bad formatting seen here: 

![](http://i.imgur.com/iaZHmIg.png)