### PR TITLE
Clarify that repr(any integer type) is legal

### DIFF
--- a/src/other-reprs.md
+++ b/src/other-reprs.md
@@ -53,7 +53,7 @@ compiled as normal.)
 
 
 
-# repr(u8), repr(u16), repr(u32), repr(u64)
+# repr(u*), repr(i*)
 
 These specify the size to make a C-like enum. If the discriminant overflows the
 integer it has to fit in, it will produce a compile-time error. You can manually


### PR DESCRIPTION
The previous title suggested that `repr(isize)`, for example, was not valid.

I'm not sure if this is great wording, or whether we should add some examples, but I think we can improve the heading.