### PR TITLE
Merge branch 42959 into master

### DIFF
--- a/src/vec-final.md
+++ b/src/vec-final.md
@@ -49,7 +49,7 @@ impl<T> RawVec<T> {
                 Err(err) => Heap.oom(err),
             };
 
-            self.ptr = Unique::new(ptr as *mut _);
+            self.ptr = Unique::new_unchecked(ptr as *mut _);
             self.cap = new_cap;
         }
     }


### PR DESCRIPTION
This branch was intended to be temporary, but https://github.com/rust-lang/rust/pull/42959 landed using it. Merging into master so that rust-lang/rust’s commit history doesn’t break.