### PR TITLE
Update exotic-sizes.md

### DIFF
--- a/src/exotic-sizes.md
+++ b/src/exotic-sizes.md
@@ -39,12 +39,6 @@ struct Foo {
 }
 ```
 
-**NOTE: [As of Rust 1.0 struct DSTs are broken if the last field has
-a variable position based on its alignment][dst-issue].**
-
-
-
-
 
 # Zero Sized Types (ZSTs)
 


### PR DESCRIPTION
[This issue](https://github.com/rust-lang/rust/issues/26403) was fixed quite some time ago. The warning should no longer be necessary.