### PR TITLE
Expand first-in-book use of certain abbreviations

### DIFF
--- a/src/other-reprs.md
+++ b/src/other-reprs.md
@@ -37,10 +37,10 @@ still consumes a byte of space.
   difference from a struct is that the fields aren’t named.
 
 * This is equivalent to one of `repr(u*)` (see the next section) for enums. The
-chosen size is the default enum size for the target platform's C ABI. Note that
-enum representation in C is implementation defined, so this is really a "best
-guess". In particular, this may be incorrect when the C code of interest is
-compiled with certain flags.
+chosen size is the default enum size for the target platform's C application
+binary interface (ABI). Note that enum representation in C is implementation
+defined, so this is really a "best guess". In particular, this may be incorrect
+when the C code of interest is compiled with certain flags.
 
 * "C-like" enums with `repr(C)` or `repr(u*)` still may not be set to an
 integer value without a corresponding variant, even though this is

--- a/src/safe-unsafe-meaning.md
+++ b/src/safe-unsafe-meaning.md
@@ -38,8 +38,8 @@ The standard library has a number of unsafe functions, including:
   type safety in arbitrary ways (see [conversions] for details).
 * Every raw pointer to a sized type has an `offset` method that
   invokes Undefined Behavior if the passed offset is not ["in bounds"][ptr_offset].
-* All FFI functions are `unsafe` to call because the other language can do
-  arbitrary operations that the Rust compiler can't check.
+* All FFI (Foreign Function Interface) functions are `unsafe` to call because the
+  other language can do arbitrary operations that the Rust compiler can't check.
 
 As of Rust 1.0 there are exactly two unsafe traits:
 


### PR DESCRIPTION
I recently read the nomicon to delve deeper into the language. I noticed that a couple of abbreviations were never explained. These unexplained, although common abbreviations can trip a reader, as at least ABI was not immediately clear to me.