### PR TITLE
The `unique` feature is renamed `ptr_internals`

### DIFF
--- a/src/destructors.md
+++ b/src/destructors.md
@@ -26,7 +26,7 @@ this is totally fine.
 For instance, a custom implementation of `Box` might write `Drop` like this:
 
 ```rust
-#![feature(unique, allocator_api)]
+#![feature(ptr_internals, allocator_api)]
 
 use std::heap::{Heap, Alloc, Layout};
 use std::mem;
@@ -52,7 +52,7 @@ use-after-free the `ptr` because when drop exits, it becomes inaccessible.
 However this wouldn't work:
 
 ```rust
-#![feature(allocator_api, unique)]
+#![feature(allocator_api, ptr_internals)]
 
 use std::heap::{Heap, Alloc, Layout};
 use std::ptr::{drop_in_place, Unique};
@@ -123,7 +123,7 @@ The classic safe solution to overriding recursive drop and allowing moving out
 of Self during `drop` is to use an Option:
 
 ```rust
-#![feature(allocator_api, unique)]
+#![feature(allocator_api, ptr_internals)]
 
 use std::heap::{Alloc, Heap, Layout};
 use std::ptr::{drop_in_place, Unique};

--- a/src/vec-final.md
+++ b/src/vec-final.md
@@ -1,7 +1,7 @@
 # The Final Code
 
 ```rust
-#![feature(unique)]
+#![feature(ptr_internals)]
 #![feature(allocator_api)]
 
 use std::ptr::{Unique, self};

--- a/src/vec-layout.md
+++ b/src/vec-layout.md
@@ -71,7 +71,7 @@ take the hit and use std's Unique:
 
 
 ```rust
-#![feature(unique)]
+#![feature(ptr_internals)]
 
 use std::ptr::{Unique, self};
 


### PR DESCRIPTION
Same as https://github.com/rust-lang-nursery/nomicon/pull/48, but into a temporary branch. Once this is merged https://github.com/rust-lang/rust/pull/46952 can update the submodule to that branch. After *that* reaches Nightly, the branch can be merged into master.