### PR TITLE
Fix code example compilation errors related to `unique`.

### DIFF
--- a/src/destructors.md
+++ b/src/destructors.md
@@ -26,7 +26,7 @@ this is totally fine.
 For instance, a custom implementation of `Box` might write `Drop` like this:
 
 ```rust
-#![feature(ptr_internals, allocator_api)]
+#![feature(ptr_internals, allocator_api, unique)]
 
 use std::heap::{Heap, Alloc, Layout};
 use std::mem;
@@ -52,7 +52,7 @@ use-after-free the `ptr` because when drop exits, it becomes inaccessible.
 However this wouldn't work:
 
 ```rust
-#![feature(allocator_api, ptr_internals)]
+#![feature(allocator_api, ptr_internals, unique)]
 
 use std::heap::{Heap, Alloc, Layout};
 use std::ptr::{drop_in_place, Unique};
@@ -123,7 +123,7 @@ The classic safe solution to overriding recursive drop and allowing moving out
 of Self during `drop` is to use an Option:
 
 ```rust
-#![feature(allocator_api, ptr_internals)]
+#![feature(allocator_api, ptr_internals, unique)]
 
 use std::heap::{Alloc, Heap, Layout};
 use std::ptr::{drop_in_place, Unique};

--- a/src/vec-final.md
+++ b/src/vec-final.md
@@ -3,6 +3,7 @@
 ```rust
 #![feature(ptr_internals)]
 #![feature(allocator_api)]
+#![feature(unique)]
 
 use std::ptr::{Unique, self};
 use std::mem;

--- a/src/vec-layout.md
+++ b/src/vec-layout.md
@@ -71,7 +71,7 @@ take the hit and use std's Unique:
 
 
 ```rust
-#![feature(ptr_internals)]
+#![feature(ptr_internals, unique)]
 
 use std::ptr::{Unique, self};
 


### PR DESCRIPTION
Prior to this commit, `mdbook test` was failing