### PR TITLE
Replace word 'covariance' with 'variance' for consistency.

### DIFF
--- a/src/phantom-data.md
+++ b/src/phantom-data.md
@@ -70,7 +70,7 @@ that:
 use std::marker;
 
 struct Vec<T> {
-    data: *const T, // *const for covariance!
+    data: *const T, // *const for variance!
     len: usize,
     cap: usize,
     _marker: marker::PhantomData<T>,


### PR DESCRIPTION
Replaces term 'covariance' with 'variance' to ensure consistency with other parts in the [Subtyping and Variance](https://doc.rust-lang.org/nomicon/subtyping.html) section and others.
The term 'covariance' is not used except for supplementary information for those familiar with type theory.