### PR TITLE
Update description of float casts

### DIFF
--- a/src/casts.md
+++ b/src/casts.md
@@ -56,16 +56,11 @@ For numeric casts, there are quite a few cases to consider:
       value cannot be represented by the target integer type][float-int]**.
       This includes Inf and NaN. This is a bug and will be fixed.
 * casting from an integer to float will produce the floating point
-  representation of the integer, rounded if necessary (rounding strategy
-  unspecified)
+  representation of the integer, rounded if necessary (rounding to
+  nearest, ties to even)
 * casting from an f32 to an f64 is perfect and lossless
 * casting from an f64 to an f32 will produce the closest possible value
-  (rounding strategy unspecified)
-    * **[NOTE: currently this will cause Undefined Behavior if the value
-      is finite but larger or smaller than the largest or smallest finite
-      value representable by f32][float-float]**. This is a bug and will
-      be fixed.
+  (rounding to nearest, ties to even)
 
 
 [float-int]: https://github.com/rust-lang/rust/issues/10184
-[float-float]: https://github.com/rust-lang/rust/issues/15536


### PR DESCRIPTION
https://github.com/rust-lang/rust/issues/15536 has been closed, there's no UB there, so let's stop linking to it. And for the same reasons (LLVM's assumption of the default floating point environment), f64->f32 and int->float casts do actually have a defined rounding mode, ties-to-even.