### PR TITLE
Fix test failure, `oom` has been renamed to `handle_alloc_error`.

### DIFF
--- a/src/vec-final.md
+++ b/src/vec-final.md
@@ -9,7 +9,7 @@ use std::ptr::{Unique, NonNull, self};
 use std::mem;
 use std::ops::{Deref, DerefMut};
 use std::marker::PhantomData;
-use std::alloc::{Alloc, GlobalAlloc, Layout, Global, oom};
+use std::alloc::{Alloc, GlobalAlloc, Layout, Global, handle_alloc_error};
 
 struct RawVec<T> {
     ptr: Unique<T>,
@@ -45,9 +45,9 @@ impl<T> RawVec<T> {
                 (new_cap, ptr)
             };
 
-            // If allocate or reallocate fail, oom
+            // If allocate or reallocate fail, handle it
             if ptr.is_err() {
-                oom(Layout::from_size_align_unchecked(
+                handle_alloc_error(Layout::from_size_align_unchecked(
                     new_cap * elem_size,
                     mem::align_of::<T>(),
                 ))


### PR DESCRIPTION
See rust-lang/rust#51543.