### PR TITLE
unpin mdbook version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ rust:
   - nightly
 
 before_script:
-  - (cargo install mdbook --force --vers "0.1.7" || true)
+  - (cargo install mdbook --force || true)
 
 script:
   - export PATH=$PATH:/home/travis/.cargo/bin;


### PR DESCRIPTION
Version 0.1.9 has been release and should fix `mdbook test`.