### PR TITLE
Remove `unique` feature which doesn't exist anymore

### DIFF
--- a/src/destructors.md
+++ b/src/destructors.md
@@ -26,7 +26,7 @@ this is totally fine.
 For instance, a custom implementation of `Box` might write `Drop` like this:
 
 ```rust
-#![feature(ptr_internals, allocator_api, unique)]
+#![feature(ptr_internals, allocator_api)]
 
 use std::alloc::{Alloc, Global, GlobalAlloc, Layout};
 use std::mem;
@@ -53,7 +53,7 @@ use-after-free the `ptr` because when drop exits, it becomes inaccessible.
 However this wouldn't work:
 
 ```rust
-#![feature(allocator_api, ptr_internals, unique)]
+#![feature(allocator_api, ptr_internals)]
 
 use std::alloc::{Alloc, Global, GlobalAlloc, Layout};
 use std::ptr::{drop_in_place, Unique, NonNull};
@@ -126,7 +126,7 @@ The classic safe solution to overriding recursive drop and allowing moving out
 of Self during `drop` is to use an Option:
 
 ```rust
-#![feature(allocator_api, ptr_internals, unique)]
+#![feature(allocator_api, ptr_internals)]
 
 use std::alloc::{Alloc, GlobalAlloc, Global, Layout};
 use std::ptr::{drop_in_place, Unique, NonNull};

--- a/src/vec-final.md
+++ b/src/vec-final.md
@@ -3,7 +3,6 @@
 ```rust
 #![feature(ptr_internals)]
 #![feature(allocator_api)]
-#![feature(unique)]
 
 use std::ptr::{Unique, NonNull, self};
 use std::mem;

--- a/src/vec-layout.md
+++ b/src/vec-layout.md
@@ -71,7 +71,7 @@ take the hit and use std's Unique:
 
 
 ```rust
-#![feature(ptr_internals, unique)]
+#![feature(ptr_internals)]
 
 use std::ptr::{Unique, self};
 


### PR DESCRIPTION
`Unique` was marked permanently-unstable in rust#46952 and its feature
flag was changed to `ptr_internals` which we're already using.

See https://github.com/rust-lang/rust/pull/46952.
Required to fix [toolstate](https://rust-lang-nursery.github.io/rust-toolstate/) as https://github.com/rust-lang/rust/pull/52644 introduced an error when an unknown feature is encountered. edit: This would also unblock nightlies.