### PR TITLE
Change compiler error message format to new format

### DIFF
--- a/src/borrow-splitting.md
+++ b/src/borrow-splitting.md
@@ -34,21 +34,18 @@ println!("{} {}", a, b);
 ```
 
 ```text
-<anon>:4:14: 4:18 error: cannot borrow `x[..]` as mutable more than once at a time
-<anon>:4 let b = &mut x[1];
-                      ^~~~
-<anon>:3:14: 3:18 note: previous borrow of `x[..]` occurs here; the mutable borrow prevents subsequent moves, borrows, or modification of `x[..]` until the borrow ends
-<anon>:3 let a = &mut x[0];
-                      ^~~~
-<anon>:6:2: 6:2 note: previous borrow ends here
-<anon>:1 fn main() {
-<anon>:2 let mut x = [1, 2, 3];
-<anon>:3 let a = &mut x[0];
-<anon>:4 let b = &mut x[1];
-<anon>:5 println!("{} {}", a, b);
-<anon>:6 }
-         ^
-error: aborting due to 2 previous errors
+error[E0499]: cannot borrow `x[..]` as mutable more than once at a time
+ --> src/lib.rs:4:18
+  |
+3 |     let a = &mut x[0];
+  |                  ---- first mutable borrow occurs here
+4 |     let b = &mut x[1];
+  |                  ^^^^ second mutable borrow occurs here
+5 |     println!("{} {}", a, b);
+6 | }
+  | - first borrow ends here
+
+error: aborting due to previous error
 ```
 
 While it was plausible that borrowck could understand this simple case, it's

--- a/src/checked-uninit.md
+++ b/src/checked-uninit.md
@@ -12,9 +12,9 @@ fn main() {
 ```
 
 ```text
-src/main.rs:3:20: 3:21 error: use of possibly uninitialized variable: `x`
-src/main.rs:3     println!("{}", x);
-                                 ^
+  |
+3 |     println!("{}", x);
+  |                    ^ use of possibly uninitialized `x`
 ```
 
 This is based off of a basic branch analysis: every branch must assign a value
@@ -50,8 +50,9 @@ fn main() {
 ```
 
 ```text
-src/main.rs:6:17: 6:18 error: use of possibly uninitialized variable: `x`
-src/main.rs:6   println!("{}", x);
+  |
+6 |     println!("{}", x);
+  |                    ^ use of possibly uninitialized `x`
 ```
 
 while this does:

--- a/src/coercions.md
+++ b/src/coercions.md
@@ -58,7 +58,6 @@ fn foo<X: Trait>(t: X) {}
 
 impl<'a> Trait for &'a i32 {}
 
-
 fn main() {
     let t: &mut i32 = &mut 0;
     foo(t);
@@ -66,7 +65,19 @@ fn main() {
 ```
 
 ```text
-<anon>:10:5: 10:8 error: the trait bound `&mut i32 : Trait` is not satisfied [E0277]
-<anon>:10     foo(t);
-              ^~~
+error[E0277]: the trait bound `&mut i32: Trait` is not satisfied
+ --> src/main.rs:9:5
+  |
+9 |     foo(t);
+  |     ^^^ the trait `Trait` is not implemented for `&mut i32`
+  |
+  = help: the following implementations were found:
+            <&'a i32 as Trait>
+note: required by `foo`
+ --> src/main.rs:3:1
+  |
+3 | fn foo<X: Trait>(t: X) {}
+  | ^^^^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to previous error
 ```

--- a/src/dropck.md
+++ b/src/dropck.md
@@ -80,14 +80,14 @@ fn main() {
 ```
 
 ```text
-error: `days` does not live long enough
-  --> <anon>:15:1
+error[E0597]: `days` does not live long enough
+  --> src/main.rs:12:28
    |
 12 |     inspector = Inspector(&days);
-   |                            ---- borrow occurs here
+   |                            ^^^^ borrowed value does not live long enough
 ...
 15 | }
-   | ^ `days` dropped here while still borrowed
+   | - `days` dropped here while still borrowed
    |
    = note: values in a scope are dropped in the opposite order they are created
 

--- a/src/lifetime-mismatch.md
+++ b/src/lifetime-mismatch.md
@@ -24,19 +24,15 @@ would expect `foo.share()` to succeed as `foo` shouldn't be mutably borrowed.
 However when we try to compile it:
 
 ```text
-<anon>:11:5: 11:8 error: cannot borrow `foo` as immutable because it is also borrowed as mutable
-<anon>:11     foo.share();
-              ^~~
-<anon>:10:16: 10:19 note: previous borrow of `foo` occurs here; the mutable borrow prevents subsequent moves, borrows, or modification of `foo` until the borrow ends
-<anon>:10     let loan = foo.mutate_and_share();
-                         ^~~
-<anon>:12:2: 12:2 note: previous borrow ends here
-<anon>:8 fn main() {
-<anon>:9     let mut foo = Foo;
-<anon>:10     let loan = foo.mutate_and_share();
-<anon>:11     foo.share();
-<anon>:12 }
-          ^
+error[E0502]: cannot borrow `foo` as immutable because it is also borrowed as mutable
+  --> src/lib.rs:11:5
+   |
+10 |     let loan = foo.mutate_and_share();
+   |                --- mutable borrow occurs here
+11 |     foo.share();
+   |     ^^^ immutable borrow occurs here
+12 | }
+   | - mutable borrow ends here
 ```
 
 What happened? Well, we got the exact same reasoning as we did for


### PR DESCRIPTION
Fixes #89 

This changes all the compiler error messages to use the new (more readable) format. 