### PR TITLE
Add missing source code language hints in drop-flags and phantom-data.

### DIFF
--- a/src/drop-flags.md
+++ b/src/drop-flags.md
@@ -12,7 +12,7 @@ Note that this is not a problem that all assignments need worry about. In
 particular, assigning through a dereference unconditionally drops, and assigning
 in a `let` unconditionally doesn't drop:
 
-```
+```rust
 let mut x = Box::new(0); // let makes a fresh variable, so never need to drop
 let y = &mut x;
 *y = Box::new(1); // Deref assumes the referent is initialized, so always drops

--- a/src/phantom-data.md
+++ b/src/phantom-data.md
@@ -27,7 +27,7 @@ useful such as the information needed by drop check.
 Iter logically contains a bunch of `&'a T`s, so this is exactly what we tell
 the PhantomData to simulate:
 
-```
+```rust
 use std::marker;
 
 struct Iter<'a, T: 'a> {
@@ -42,7 +42,7 @@ over `'a` and `T`. Everything Just Works.
 
 Another important example is Vec, which is (approximately) defined as follows:
 
-```
+```rust
 struct Vec<T> {
     data: *const T, // *const for variance!
     len: usize,
@@ -66,7 +66,7 @@ In order to tell dropck that we *do* own values of type T, and therefore may
 drop some T's when *we* drop, we must add an extra PhantomData saying exactly
 that:
 
-```
+```rust
 use std::marker;
 
 struct Vec<T> {


### PR DESCRIPTION
Just discovered that a few source code snippets in `phantom-data.md` and `drop-flags.md` missed their syntax highlighting.