### PR TITLE
Fix typo in subtyping.md

### DIFF
--- a/src/subtyping.md
+++ b/src/subtyping.md
@@ -306,7 +306,7 @@ fn evil_feeder<T>(input: &mut T, val: T) {
 }
 ```
 
-All it does it take a mutable reference and a value and overwrite the referent with it.
+All it does is take a mutable reference and a value and overwrite the referent with it.
 What's important about this function is that it creates a type equality constraint. It
 clearly says in its signature the referent and the value must be the *exact same* type.
 


### PR DESCRIPTION
This sentence could probably be slightly tweaked; the last 'it' is a little ambiguous. In any case, the fix in this patch is just a copy error.