### PR TITLE
Small README.md cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,11 +6,11 @@ Nicknamed "the Nomicon."
 
 ## NOTE: This is a draft document, and may contain serious errors
 
-> Instead of the programs I had hoped for, there came only a shuddering blackness
-and ineffable loneliness; and I saw at last a fearful truth which no one had
-ever dared to breathe before — the unwhisperable secret of secrets — The fact
-that this language of stone and stridor is not a sentient perpetuation of Rust
-as London is of Old London and Paris of Old Paris, but that it is in fact
+> Instead of the programs I had hoped for, there came only a shuddering
+blackness and ineffable loneliness; and I saw at last a fearful truth which no
+one had ever dared to breathe before — the unwhisperable secret of secrets — The
+fact that this language of stone and stridor is not a sentient perpetuation of
+Rust as London is of Old London and Paris of Old Paris, but that it is in fact
 quite unsafe, its sprawling body imperfectly embalmed and infested with queer
 animate things which have nothing to do with it as it was in compilation.
 

--- a/README.md
+++ b/README.md
@@ -29,34 +29,24 @@ Building the Nomicon requires [mdBook]. To get it:
 $ cargo install mdbook
 ```
 
-### Building
+### `mdbook` usage
 
-To build the Nomicon:
+To build the Nomicon use the `build` sub-command:
 
 ```bash
 $ mdbook build
 ```
 
-The output will be in the `book` subdirectory. To check it out, open it in
-your web browser.
+The output will be placed in the `book` subdirectory. To check it out, open the
+`index.html` file in your web browser. You can pass the `--open` flag to `mdbook
+build` and it'll open the index page (if the process is successful) just like with
+`cargo doc --open`:
 
-_Firefox:_
 ```bash
-$ firefox book/index.html                       # Linux
-$ open -a "Firefox" book/index.html             # OS X
-$ Start-Process "firefox.exe" .\book\index.html # Windows (PowerShell)
-$ start firefox.exe .\book\index.html           # Windows (Cmd)
+$ mdbook build --open
 ```
 
-_Chrome:_
-```bash
-$ google-chrome book/index.html                 # Linux
-$ open -a "Google Chrome" book/index.html       # OS X
-$ Start-Process "chrome.exe" .\book\index.html  # Windows (PowerShell)
-$ start chrome.exe .\book\index.html            # Windows (Cmd)
-```
-
-To run the tests:
+There is also a `test` sub-command to test all code samples contained in the book:
 
 ```bash
 $ mdbook test

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ infinitesimal fragments of despair.
 
 Building the Nomicon requires [mdBook]. To get it:
 
-[mdBook]: https://github.com/azerupi/mdBook
+[mdBook]: https://github.com/rust-lang-nursery/mdBook
 
 ```bash
 $ cargo install mdbook

--- a/README.md
+++ b/README.md
@@ -39,8 +39,8 @@ $ mdbook build
 
 The output will be placed in the `book` subdirectory. To check it out, open the
 `index.html` file in your web browser. You can pass the `--open` flag to `mdbook
-build` and it'll open the index page (if the process is successful) just like with
-`cargo doc --open`:
+build` and it'll open the index page in your default browser (if the process is
+successful) just like with `cargo doc --open`:
 
 ```bash
 $ mdbook build --open
@@ -54,7 +54,8 @@ $ mdbook test
 
 ## Contributing
 
-Given that the Nomicon is still in a draft state, we'd love your help! Please feel free to open
-issues about anything, and send in PRs for things you'd like to fix or change. If your change is
-large, please open an issue first, so we can make sure that it's something we'd accept before you
-go through the work of getting a PR together.
+Given that the Nomicon is still in a draft state, we'd love your help! Please
+feel free to open issues about anything, and send in PRs for things you'd like
+to fix or change. If your change is large, please open an issue first, so we can
+make sure that it's something we'd accept before you go through the work of
+getting a PR together.


### PR DESCRIPTION
* Re-wrap the text to fit in 80 columns.
* Suggest that people use `mdbook build --open` (similar to `cargo doc --open`) to open the book instead of having them worry about what specific OS and browser they're using.
* Make the link to the `mdbook` repo go directly to the current home of `mdbook` in the `rust-lang-nursery`  instead of relying on GitHub to redirect.