### PR TITLE
chore: Remove redundant Eq import

### DIFF
--- a/src/lifetime-mismatch.md
+++ b/src/lifetime-mismatch.md
@@ -80,7 +80,6 @@ This will eventually get fixed.
 
 ```rust,edition2018,compile_fail
 # use std::collections::HashMap;
-# use std::cmp::Eq;
 # use std::hash::Hash;
 fn get_default<'m, K, V>(map: &'m mut HashMap<K, V>, key: K) -> &'m mut V
 where


### PR DESCRIPTION
When build on playground:
```
   Compiling playground v0.0.1 (/playground)
warning: the item `Eq` is imported redundantly
 --> src/main.rs:5:5
  |
5 | use std::cmp::Eq;
  |     ^^^^^^^^^^^^
  |
  = note: #[warn(unused_imports)] on by default
```
