### PR TITLE
Add comma to `MySuperSliceable` too

### DIFF
--- a/src/exotic-sizes.md
+++ b/src/exotic-sizes.md
@@ -51,7 +51,7 @@ and performing an *unsizing coercion*:
 ```rust
 struct MySuperSliceable<T: ?Sized> {
     info: u32,
-    data: T
+    data: T,
 }
 
 fn main() {


### PR DESCRIPTION
Added comma to `MySuperSliceable` like the other struct in `exotic-sizes`.

```
struct MySuperSlice {
    info: u32,
    data: [u8],
}
```

```
struct MySuperSliceable<T: ?Sized> {
    info: u32,
    data: T    <- probably needed in here too?
}
```
