### PR TITLE
s/railguard/guardrail/

### DIFF
--- a/src/transmutes.md
+++ b/src/transmutes.md
@@ -4,7 +4,7 @@ Get out of our way type system! We're going to reinterpret these bits or die
 trying! Even though this book is all about doing things that are unsafe, I
 really can't emphasize that you should deeply think about finding Another Way
 than the operations covered in this section. This is really, truly, the most
-horribly unsafe thing you can do in Rust. The railguards here are dental floss.
+horribly unsafe thing you can do in Rust. The guardrails here are dental floss.
 
 [`mem::transmute<T, U>`][transmute] takes a value of type `T` and reinterprets
 it to have type `U`. The only restriction is that the `T` and `U` are verified


### PR DESCRIPTION
Train terminology nit. Sorry!

Rail guard: A device attached to the front of a locomotive on each side for clearing the rail of obstructions.

Guard rail: A rail set alongside a dangerous place in order to improve safety.