### PR TITLE
Fix the versioning of libc

### DIFF
--- a/src/ffi.md
+++ b/src/ffi.md
@@ -16,7 +16,7 @@ examples yourself, you’ll need to add `libc` to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-libc = "0.2.0"
+libc = "0.2"
 ```
 
 [libc]: https://crates.io/crates/libc


### PR DESCRIPTION
The following versioning 
`libc = "0.2"` 
should be better? 

ref:[crate.io](https://crates.io/crates/libc), [README](https://github.com/rust-lang/libc)